### PR TITLE
Fix local broker call handling

### DIFF
--- a/ee/packages/network-broker/src/NetworkBroker.ts
+++ b/ee/packages/network-broker/src/NetworkBroker.ts
@@ -152,21 +152,21 @@ export class NetworkBroker implements IBroker {
 		this.broker.createService(service);
 	}
 
-	async broadcast<T extends keyof EventSignatures>(event: T, ...args: Parameters<EventSignatures[T]>): Promise<void> {
-		return this.broker.broadcast(event, args);
-	}
+       async broadcast<T extends keyof EventSignatures>(event: T, ...args: Parameters<EventSignatures[T]>): Promise<void> {
+               return this.broker.broadcast(event, ...args);
+       }
 
-	async broadcastLocal<T extends keyof EventSignatures>(event: T, ...args: Parameters<EventSignatures[T]>): Promise<void> {
-		void this.broker.broadcastLocal(event, args);
-	}
+       async broadcastLocal<T extends keyof EventSignatures>(event: T, ...args: Parameters<EventSignatures[T]>): Promise<void> {
+               void this.broker.broadcastLocal(event, ...args);
+       }
 
-	async broadcastToServices<T extends keyof EventSignatures>(
-		services: string[],
-		event: T,
-		...args: Parameters<EventSignatures[T]>
-	): Promise<void> {
-		void this.broker.broadcast(event, args, services);
-	}
+       async broadcastToServices<T extends keyof EventSignatures>(
+               services: string[],
+               event: T,
+               ...args: Parameters<EventSignatures[T]>
+       ): Promise<void> {
+               void this.broker.broadcastToServices(services, event, ...args);
+       }
 
 	async nodeList(): Promise<IBrokerNode[]> {
 		return this.broker.call('$node.list');

--- a/packages/core-services/jest.config.ts
+++ b/packages/core-services/jest.config.ts
@@ -2,5 +2,8 @@ import server from '@rocket.chat/jest-presets/server';
 import type { Config } from 'jest';
 
 export default {
-	preset: server.preset,
+       preset: server.preset,
+       moduleNameMapper: {
+               '^@rocket.chat/models$': '<rootDir>/../models/src',
+       },
 } satisfies Config;

--- a/packages/core-services/src/LocalBroker.ts
+++ b/packages/core-services/src/LocalBroker.ts
@@ -17,33 +17,39 @@ export class LocalBroker implements IBroker {
 
 	private services = new Set<IServiceClass>();
 
-       async call(method: string, data: any): Promise<any> {
-               return tracerActiveSpan(
-                       `action ${method}`,
-                       {},
-                       () => {
-                               return asyncLocalStorage.run(
-                                       {
-                                               id: 'ctx.id',
-                                               nodeID: 'ctx.nodeID',
-                                               requestID: 'ctx.requestID',
-                                               broker: this,
-                                       },
-                                       (): any => {
-                                               const fn = this.methods.get(method);
-                                               if (!fn) {
-                                                       return;
-                                               }
-                                               return Array.isArray(data) ? fn(...data) : fn(data);
-                                       },
-                               );
-                       },
-                       injectCurrentContext(),
-               );
-       }
+	async call(method: string, data?: any): Promise<any> {
+		return tracerActiveSpan(
+			`action ${method}`,
+			{},
+			() => {
+				return asyncLocalStorage.run(
+					{
+						id: 'ctx.id',
+						nodeID: 'ctx.nodeID',
+						requestID: 'ctx.requestID',
+						broker: this,
+					},
+					(): any => {
+						const fn = this.methods.get(method);
+						if (!fn) {
+							return;
+						}
+						if (Array.isArray(data)) {
+							return fn(...data);
+						}
+						if (typeof data === 'undefined') {
+							return fn();
+						}
+						return fn(data);
+					},
+				);
+			},
+			injectCurrentContext(),
+		);
+	}
 
-        async destroyService(instance: ServiceClass): Promise<void> {
-                const namespace = instance.getName();
+	async destroyService(instance: ServiceClass): Promise<void> {
+		const namespace = instance.getName();
 
 		instance.getEvents().forEach((event) => event.listeners.forEach((listener) => this.events.removeListener(event.eventName, listener)));
 
@@ -58,10 +64,10 @@ export class LocalBroker implements IBroker {
 
 			this.methods.delete(`${namespace}.${method}`);
 		}
-                instance.removeAllListeners();
-                await instance.stopped();
-                this.services.delete(instance);
-        }
+		instance.removeAllListeners();
+		await instance.stopped();
+		this.services.delete(instance);
+	}
 
 	createService(instance: IServiceClass): void {
 		const namespace = instance.getName();

--- a/packages/core-services/src/LocalBroker.ts
+++ b/packages/core-services/src/LocalBroker.ts
@@ -17,24 +17,30 @@ export class LocalBroker implements IBroker {
 
 	private services = new Set<IServiceClass>();
 
-	async call(method: string, data: any): Promise<any> {
-		return tracerActiveSpan(
-			`action ${method}`,
-			{},
-			() => {
-				return asyncLocalStorage.run(
-					{
-						id: 'ctx.id',
-						nodeID: 'ctx.nodeID',
-						requestID: 'ctx.requestID',
-						broker: this,
-					},
-					(): any => this.methods.get(method)?.(...data),
-				);
-			},
-			injectCurrentContext(),
-		);
-	}
+       async call(method: string, data: any): Promise<any> {
+               return tracerActiveSpan(
+                       `action ${method}`,
+                       {},
+                       () => {
+                               return asyncLocalStorage.run(
+                                       {
+                                               id: 'ctx.id',
+                                               nodeID: 'ctx.nodeID',
+                                               requestID: 'ctx.requestID',
+                                               broker: this,
+                                       },
+                                       (): any => {
+                                               const fn = this.methods.get(method);
+                                               if (!fn) {
+                                                       return;
+                                               }
+                                               return Array.isArray(data) ? fn(...data) : fn(data);
+                                       },
+                               );
+                       },
+                       injectCurrentContext(),
+               );
+       }
 
 	async destroyService(instance: ServiceClass): Promise<void> {
 		const namespace = instance.getName();

--- a/packages/core-services/src/LocalBroker.ts
+++ b/packages/core-services/src/LocalBroker.ts
@@ -42,8 +42,8 @@ export class LocalBroker implements IBroker {
                );
        }
 
-	async destroyService(instance: ServiceClass): Promise<void> {
-		const namespace = instance.getName();
+        async destroyService(instance: ServiceClass): Promise<void> {
+                const namespace = instance.getName();
 
 		instance.getEvents().forEach((event) => event.listeners.forEach((listener) => this.events.removeListener(event.eventName, listener)));
 
@@ -58,9 +58,10 @@ export class LocalBroker implements IBroker {
 
 			this.methods.delete(`${namespace}.${method}`);
 		}
-		instance.removeAllListeners();
-		await instance.stopped();
-	}
+                instance.removeAllListeners();
+                await instance.stopped();
+                this.services.delete(instance);
+        }
 
 	createService(instance: IServiceClass): void {
 		const namespace = instance.getName();

--- a/packages/core-services/tests/LocalBroker.test.ts
+++ b/packages/core-services/tests/LocalBroker.test.ts
@@ -24,8 +24,8 @@ describe('LocalBroker', () => {
 		});
 	});
 
-	describe('#destroyService()', () => {
-		it('should call all the expected lifecycle hooks when destroying a service', () => {
+        describe('#destroyService()', () => {
+                it('should call all the expected lifecycle hooks when destroying a service', () => {
 			const removeAllListenersStub = jest.fn();
 			const stoppedStub = jest.fn();
 			const instance = new (class extends ServiceClass {
@@ -42,10 +42,27 @@ describe('LocalBroker', () => {
 			broker.createService(instance);
 			broker.destroyService(instance);
 
-			expect(removeAllListenersStub).toBeCalled();
-			expect(stoppedStub).toBeCalled();
-		});
-	});
+                        expect(removeAllListenersStub).toBeCalled();
+                        expect(stoppedStub).toBeCalled();
+                });
+
+                it('should remove the service from the internal registry', async () => {
+                        const startedStub = jest.fn();
+                        const instance = new (class extends ServiceClass {
+                                async started() {
+                                        startedStub();
+                                }
+                        })();
+
+                        const broker = new LocalBroker();
+                        broker.createService(instance);
+                        broker.destroyService(instance);
+
+                        await broker.start();
+
+                        expect(startedStub).not.toBeCalled();
+                });
+        });
 
         describe('#broadcast()', () => {
                 it('should call all the ServiceClass instance registered events', () => {

--- a/packages/core-services/tests/LocalBroker.test.ts
+++ b/packages/core-services/tests/LocalBroker.test.ts
@@ -2,9 +2,9 @@ import { ServiceClass } from '../src';
 import { LocalBroker } from '../src/LocalBroker';
 
 jest.mock('@rocket.chat/models', () => ({
-       InstanceStatus: {
-               find: jest.fn().mockReturnValue({ toArray: () => Promise.resolve([]) }),
-       },
+	InstanceStatus: {
+		find: jest.fn().mockReturnValue({ toArray: () => Promise.resolve([]) }),
+	},
 }));
 
 describe('LocalBroker', () => {
@@ -24,8 +24,8 @@ describe('LocalBroker', () => {
 		});
 	});
 
-        describe('#destroyService()', () => {
-                it('should call all the expected lifecycle hooks when destroying a service', () => {
+	describe('#destroyService()', () => {
+		it('should call all the expected lifecycle hooks when destroying a service', () => {
 			const removeAllListenersStub = jest.fn();
 			const stoppedStub = jest.fn();
 			const instance = new (class extends ServiceClass {
@@ -42,30 +42,30 @@ describe('LocalBroker', () => {
 			broker.createService(instance);
 			broker.destroyService(instance);
 
-                        expect(removeAllListenersStub).toBeCalled();
-                        expect(stoppedStub).toBeCalled();
-                });
+			expect(removeAllListenersStub).toBeCalled();
+			expect(stoppedStub).toBeCalled();
+		});
 
-                it('should remove the service from the internal registry', async () => {
-                        const startedStub = jest.fn();
-                        const instance = new (class extends ServiceClass {
-                                async started() {
-                                        startedStub();
-                                }
-                        })();
+		it('should remove the service from the internal registry', async () => {
+			const startedStub = jest.fn();
+			const instance = new (class extends ServiceClass {
+				async started() {
+					startedStub();
+				}
+			})();
 
-                        const broker = new LocalBroker();
-                        broker.createService(instance);
-                        broker.destroyService(instance);
+			const broker = new LocalBroker();
+			broker.createService(instance);
+			broker.destroyService(instance);
 
-                        await broker.start();
+			await broker.start();
 
-                        expect(startedStub).not.toBeCalled();
-                });
-        });
+			expect(startedStub).not.toBeCalled();
+		});
+	});
 
-        describe('#broadcast()', () => {
-                it('should call all the ServiceClass instance registered events', () => {
+	describe('#broadcast()', () => {
+		it('should call all the ServiceClass instance registered events', () => {
 			const instance = new (class extends ServiceClass {})();
 			const testListener = jest.fn();
 			const testListener2 = jest.fn();
@@ -84,7 +84,7 @@ describe('LocalBroker', () => {
 			expect(test2Listener).toBeCalledWith('test2');
 		});
 
-                it('should NOT call any instance event anymore after the service being destroyed', () => {
+		it('should NOT call any instance event anymore after the service being destroyed', () => {
 			const instance = new (class extends ServiceClass {})();
 			const testListener = jest.fn();
 			const test2Listener = jest.fn();
@@ -100,28 +100,49 @@ describe('LocalBroker', () => {
 
 			expect(testListener).not.toBeCalled();
 			expect(test2Listener).not.toBeCalled();
-                });
-        });
+		});
+	});
 
-       describe('#call()', () => {
-               it('should support calling a method with an object parameter', async () => {
-                       const methodStub = jest.fn();
-                       class TestService extends ServiceClass {
-                               getName() {
-                                       return 'test';
-                               }
+	describe('#call()', () => {
+		it('should support calling a method with an object parameter', async () => {
+			const methodStub = jest.fn();
+			class TestService extends ServiceClass {
+				getName() {
+					return 'test';
+				}
 
-                               method(data: { foo: string }) {
-                                       methodStub(data);
-                               }
-                       }
+				method(data: { foo: string }) {
+					methodStub(data);
+				}
+			}
 
-                       const broker = new LocalBroker();
-                       broker.createService(new TestService());
+			const broker = new LocalBroker();
+			broker.createService(new TestService());
 
-                       await broker.call('test.method', { foo: 'bar' });
+			await broker.call('test.method', { foo: 'bar' });
 
-                       expect(methodStub).toBeCalledWith({ foo: 'bar' });
-               });
-       });
+			expect(methodStub).toBeCalledWith({ foo: 'bar' });
+		});
+
+		it('should not pass undefined when no parameter is provided', async () => {
+			const methodStub = jest.fn();
+			class TestService extends ServiceClass {
+				getName() {
+					return 'test';
+				}
+
+				method() {
+					methodStub();
+				}
+			}
+
+			const broker = new LocalBroker();
+			broker.createService(new TestService());
+
+			await broker.call('test.method');
+
+			expect(methodStub).toBeCalledTimes(1);
+			expect(methodStub).toBeCalledWith();
+		});
+	});
 });

--- a/packages/core-services/tests/LocalBroker.test.ts
+++ b/packages/core-services/tests/LocalBroker.test.ts
@@ -1,6 +1,12 @@
 import { ServiceClass } from '../src';
 import { LocalBroker } from '../src/LocalBroker';
 
+jest.mock('@rocket.chat/models', () => ({
+       InstanceStatus: {
+               find: jest.fn().mockReturnValue({ toArray: () => Promise.resolve([]) }),
+       },
+}));
+
 describe('LocalBroker', () => {
 	describe('#createService()', () => {
 		it('should call all the expected lifecycle hooks when creating a service', () => {

--- a/packages/core-services/tests/LocalBroker.test.ts
+++ b/packages/core-services/tests/LocalBroker.test.ts
@@ -41,8 +41,8 @@ describe('LocalBroker', () => {
 		});
 	});
 
-	describe('#broadcast()', () => {
-		it('should call all the ServiceClass instance registered events', () => {
+        describe('#broadcast()', () => {
+                it('should call all the ServiceClass instance registered events', () => {
 			const instance = new (class extends ServiceClass {})();
 			const testListener = jest.fn();
 			const testListener2 = jest.fn();
@@ -61,7 +61,7 @@ describe('LocalBroker', () => {
 			expect(test2Listener).toBeCalledWith('test2');
 		});
 
-		it('should NOT call any instance event anymore after the service being destroyed', () => {
+                it('should NOT call any instance event anymore after the service being destroyed', () => {
 			const instance = new (class extends ServiceClass {})();
 			const testListener = jest.fn();
 			const test2Listener = jest.fn();
@@ -77,6 +77,28 @@ describe('LocalBroker', () => {
 
 			expect(testListener).not.toBeCalled();
 			expect(test2Listener).not.toBeCalled();
-		});
-	});
+                });
+        });
+
+       describe('#call()', () => {
+               it('should support calling a method with an object parameter', async () => {
+                       const methodStub = jest.fn();
+                       class TestService extends ServiceClass {
+                               getName() {
+                                       return 'test';
+                               }
+
+                               method(data: { foo: string }) {
+                                       methodStub(data);
+                               }
+                       }
+
+                       const broker = new LocalBroker();
+                       broker.createService(new TestService());
+
+                       await broker.call('test.method', { foo: 'bar' });
+
+                       expect(methodStub).toBeCalledWith({ foo: 'bar' });
+               });
+       });
 });


### PR DESCRIPTION
## Summary
- handle object params correctly in LocalBroker.call
- fix argument forwarding in NetworkBroker broadcasts
- add test for LocalBroker.call with object args

## Testing
- `yarn testunit` *(fails: Node version mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68418dd491a4832181fc07d803105cd9

## Summary by Sourcery

Fix argument handling in LocalBroker.call and NetworkBroker.broadcast methods and add a unit test for object parameters.

Bug Fixes:
- Handle object arguments correctly in LocalBroker.call when invoking service methods
- Forward arguments individually in NetworkBroker.broadcast, broadcastLocal, and broadcastToServices instead of as an array

Tests:
- Add unit test to verify LocalBroker.call supports object parameters