### PR TITLE
Add AI utilities package

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ You can develop your own app that can be integrated with Rocket.Chat. We provide
 - [Apps Engine Development](https://developer.rocket.chat/apps-engine/rocket.chat-apps-and-apps-engine)
 - [See who's using Rocket.Chat](https://www.rocket.chat/customers)
 
+## ✨ AI Utilities
+
+Rocket.Chat now ships with experimental AI helpers under `packages/ai-utils`.
+The first utility, `analyzeSentiment`, exposes simple sentiment analysis that
+other packages can leverage to build features such as automatic tone detection
+or message tagging.
+
 # 🆕 Feature Request
 
 [Rocket.Chat/feature-requests](https://github.com/RocketChat/feature-requests) is used to track Rocket.Chat feature requests and discussions. Click [here](https://github.com/RocketChat/feature-requests/issues/new?template=feature_request.md) to open a new feature request. [Feature Request Forums](https://forums.rocket.chat/c/feature-requests/8) stores the historical archives of old feature requests (up to 2018).

--- a/packages/ai-utils/README.md
+++ b/packages/ai-utils/README.md
@@ -1,0 +1,6 @@
+# AI Utils
+
+This package provides utilities to integrate simple AI features into Rocket.Chat.
+
+Currently it exposes a `analyzeSentiment` function which performs sentiment analysis of text using the open source `sentiment` library.
+

--- a/packages/ai-utils/package.json
+++ b/packages/ai-utils/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@rocket.chat/ai-utils",
+  "version": "0.0.1",
+  "main": "dist/index.js",
+  "types": "dist/index.d.ts",
+  "scripts": {
+    "build": "tsc"
+  },
+  "dependencies": {
+    "sentiment": "^5.0.2"
+  }
+}

--- a/packages/ai-utils/src/index.d.ts
+++ b/packages/ai-utils/src/index.d.ts
@@ -1,0 +1,1 @@
+export declare function analyzeSentiment(text: string): import('sentiment').Result;

--- a/packages/ai-utils/src/index.ts
+++ b/packages/ai-utils/src/index.ts
@@ -1,0 +1,6 @@
+import Sentiment from 'sentiment';
+
+export function analyzeSentiment(text: string) {
+  const sentiment = new Sentiment();
+  return sentiment.analyze(text);
+}

--- a/packages/ai-utils/tsconfig.json
+++ b/packages/ai-utils/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"]
+}


### PR DESCRIPTION
## Summary
- introduce `@rocket.chat/ai-utils` with simple sentiment analysis
- document AI utilities in README

## Testing
- `yarn testunit` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_68448bc2dd488321ae5d845d8a1157ad

## Summary by Sourcery

Add experimental AI utilities package providing a simple sentiment analysis helper

New Features:
- Introduce `@rocket.chat/ai-utils` package with an `analyzeSentiment` function

Build:
- Add package.json and build script with TypeScript configuration for the AI utilities package

Documentation:
- Document AI utilities in the main README and in the new package README