### PR TITLE
Add docs for new resend welcome email endpoint

### DIFF
--- a/packages/rest-typings/README.md
+++ b/packages/rest-typings/README.md
@@ -79,6 +79,36 @@ we use interfaces to register endpoints, so if you use a custom version, or miss
     }
 ```
 
+## Example: `users.sendWelcomeEmail`
+
+The endpoint `/v1/users.sendWelcomeEmail` allows administrators to resend the welcome email to a user.
+
+**Method:** `POST`
+
+**Body parameters**
+
+| Name  | Type   | Required | Description                        |
+|-------|--------|----------|------------------------------------|
+| email | string | Yes      | Email address of the target user. |
+
+**Example request**
+
+```bash
+curl -X POST https://yourserver/api/v1/users.sendWelcomeEmail \
+  -H "X-Auth-Token: <auth_token>" \
+  -H "X-User-Id: <user_id>" \
+  -H "Content-Type: application/json" \
+  -d '{"email": "jane.doe@example.com"}'
+```
+
+**Successful response**
+
+```json
+{
+  "success": true
+}
+```
+
 ## License
 
 MIT


### PR DESCRIPTION
## Summary
- document `users.sendWelcomeEmail` endpoint in rest typings README

## Testing
- `yarn lint packages/rest-typings/README.md` *(fails: package not in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_684491403f608321b930ff6c996f73a1

## Summary by Sourcery

Documentation:
- Document the `users.sendWelcomeEmail` endpoint in the rest-typings README, including method, parameters, example request, and example response.