### PR TITLE
Add test for subscription upgrade callout

### DIFF
--- a/apps/meteor/client/views/admin/subscription/SubscriptionCalloutLimits.spec.tsx
+++ b/apps/meteor/client/views/admin/subscription/SubscriptionCalloutLimits.spec.tsx
@@ -1,0 +1,30 @@
+import { mockAppRoot } from '@rocket.chat/mock-providers';
+import { render, screen } from '@testing-library/react';
+import React from 'react';
+
+import { SubscriptionCalloutLimits } from './SubscriptionCalloutLimits';
+import { useLicenseLimitsByBehavior } from '../../../hooks/useLicenseLimitsByBehavior';
+
+jest.mock('../../../hooks/useLicenseLimitsByBehavior');
+
+const appRoot = mockAppRoot().withTranslations('en', 'core', {
+  'subscription.callout.servicesDisruptionsMayOccur': 'Services disruptions may occur',
+  'subscription.callout.description.limitsReached_one': 'Your workspace reached the <1>{{val}}</1> license limit. <3>Manage your subscription</3> to increase limits.',
+  'subscription.callout.activeUsers': 'seats',
+});
+
+const mockUseLicenseLimitsByBehavior = useLicenseLimitsByBehavior as jest.Mock;
+
+describe('SubscriptionCalloutLimits', () => {
+  it('renders callout when upgrade is eligible', () => {
+    mockUseLicenseLimitsByBehavior.mockReturnValue({ start_fair_policy: ['activeUsers'] });
+    render(<SubscriptionCalloutLimits />, { wrapper: appRoot.build(), legacyRoot: true });
+    expect(screen.getByRole('alert')).toBeInTheDocument();
+  });
+
+  it('hides callout when no limits are returned', () => {
+    mockUseLicenseLimitsByBehavior.mockReturnValue(null);
+    render(<SubscriptionCalloutLimits />, { wrapper: appRoot.build(), legacyRoot: true });
+    expect(screen.queryByRole('alert')).not.toBeInTheDocument();
+  });
+});


### PR DESCRIPTION
## Summary
- add a UI test to ensure the subscription page callout appears or not based on license limits

## Testing
- `npx turbo run testunit --filter=./apps/meteor` *(fails: Error: connect ENETUNREACH)*

------
https://chatgpt.com/codex/tasks/task_e_6844913e5ea483218623cff1c9a47836

## Summary by Sourcery

Add UI tests for the SubscriptionCalloutLimits component to verify it displays or hides the upgrade callout based on license limit data.

Tests:
- Add test that renders the callout when license limits indicate an upgrade is available
- Add test that ensures the callout is not rendered when no license limits are returned