### PR TITLE
Add test for message export download

### DIFF
--- a/apps/meteor/tests/e2e/export-messages.spec.ts
+++ b/apps/meteor/tests/e2e/export-messages.spec.ts
@@ -1,3 +1,5 @@
+import fs from 'fs/promises';
+
 import { Users } from './fixtures/userStates';
 import { HomeChannel, Utils } from './page-objects';
 import { createTargetChannel } from './utils';
@@ -58,15 +60,39 @@ test.describe.serial('export-messages', () => {
 		await expect(poUtils.getAlertByText(`You haven't selected any messages`)).toBeVisible();
 	});
 
-	test('should be able to send messages after closing export messages', async () => {
-		await poHomeChannel.sidenav.openChat(targetChannel);
-		await poHomeChannel.tabs.kebab.click({ force: true });
-		await poHomeChannel.tabs.btnExportMessages.click();
+        test('should be able to send messages after closing export messages', async () => {
+                await poHomeChannel.sidenav.openChat(targetChannel);
+                await poHomeChannel.tabs.kebab.click({ force: true });
+                await poHomeChannel.tabs.btnExportMessages.click();
 
 		await poHomeChannel.content.getMessageByText('hello world').click();
 		await poHomeChannel.tabs.exportMessages.btnCancel.click();
-		await poHomeChannel.content.sendMessage('hello export');
+                await poHomeChannel.content.sendMessage('hello export');
 
-		await expect(poHomeChannel.content.getMessageByText('hello export')).toBeVisible();
-	});
+                await expect(poHomeChannel.content.getMessageByText('hello export')).toBeVisible();
+        });
+
+       test('should download selected messages as JSON', async ({ page }) => {
+               await poHomeChannel.sidenav.openChat(targetChannel);
+               await poHomeChannel.content.sendMessage('json download');
+               await poHomeChannel.tabs.kebab.click({ force: true });
+               await poHomeChannel.tabs.btnExportMessages.click();
+
+               await poHomeChannel.tabs.exportMessages.sendEmailMethod.click();
+               await poHomeChannel.tabs.exportMessages.getMethodByName('Download file').click();
+
+               await poHomeChannel.content.getMessageByText('json download').click();
+
+               const [download] = await Promise.all([
+                       page.waitForEvent('download'),
+                       poHomeChannel.tabs.exportMessages.btnDownload.click(),
+               ]);
+
+               await expect(download.suggestedFilename()).toMatch(/\.json$/);
+               const filePath = await download.path();
+               const content = await fs.readFile(filePath!, 'utf-8');
+               const data = JSON.parse(content);
+               expect(Array.isArray(data.messages)).toBe(true);
+               expect(data.messages.length).toBeGreaterThan(0);
+       });
 });

--- a/apps/meteor/tests/e2e/page-objects/fragments/home-flextab-exportMessages.ts
+++ b/apps/meteor/tests/e2e/page-objects/fragments/home-flextab-exportMessages.ts
@@ -23,9 +23,13 @@ export class HomeFlextabExportMessages {
 		return this.page.getByRole('textbox', { name: 'To additional emails' });
 	}
 
-	get btnSend() {
-		return this.page.locator('role=button[name="Send"]');
-	}
+        get btnSend() {
+                return this.page.locator('role=button[name="Send"]');
+        }
+
+       get btnDownload() {
+               return this.page.locator('role=button[name="Download"]');
+       }
 
 	get btnCancel() {
 		return this.page.locator('role=button[name="Cancel"]');


### PR DESCRIPTION
## Summary
- expose export messages download button in page object
- test JSON download message export

## Testing
- `yarn test:e2e apps/meteor/tests/e2e/export-messages.spec.ts` *(fails: This package doesn't seem to be present in your lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6844913d010c8321bfb56d71db8bc843

## Summary by Sourcery

Add support and an E2E test for downloading exported messages as a JSON file

Enhancements:
- Expose the Download button in the export messages page object to support file download tests

Tests:
- Add an end-to-end test to verify JSON download of selected exported messages