### PR TITLE
Add unit test for FreeSwitch event persistence

### DIFF
--- a/apps/meteor/tests/unit/server/lib/freeswitch.eventPersistence.tests.ts
+++ b/apps/meteor/tests/unit/server/lib/freeswitch.eventPersistence.tests.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import proxyquire from 'proxyquire';
+import sinon from 'sinon';
+
+type ServiceModule = typeof import('../../../../ee/server/local-services/voip-freeswitch/service');
+
+describe('VoIP FreeSwitch Service - event persistence', () => {
+        const registerEvent = sinon.stub();
+        const serviceStarterStub = class { start() {} };
+        const Service: ServiceModule['VoipFreeSwitchService'] = proxyquire.noCallThru().load('../../../../ee/server/local-services/voip-freeswitch/service', {
+                '@rocket.chat/models': { FreeSwitchEvent: { registerEvent }, FreeSwitchCall: {}, Users: {} },
+                '../../../../app/settings/server': { settings: { get: sinon.stub() } },
+                '@rocket.chat/core-services': { ServiceStarter: serviceStarterStub },
+        }).VoipFreeSwitchService;
+
+        let service: InstanceType<Service>;
+        beforeEach(() => {
+                registerEvent.resetHistory();
+                service = new Service();
+                sinon.stub(service as any, 'parseEventData').resolves({ eventName: 'CHANNEL_CREATE', call: { UUID: '123' } });
+        });
+
+        afterEach(() => {
+                (service as any).parseEventData.restore();
+        });
+
+        it('should write parsed events using the FreeSwitchEvent model', async () => {
+                await (service as any).onFreeSwitchEvent('CHANNEL_CREATE', { 'Unique-ID': 'u1', 'Channel-Call-UUID': '123' });
+                expect(registerEvent.calledOnce).to.be.true;
+                expect(registerEvent.firstCall.args[0]).to.have.property('call');
+                expect(registerEvent.firstCall.args[0].call).to.have.property('UUID', '123');
+        });
+});


### PR DESCRIPTION
## Summary
- add a unit test verifying VoIP FreeSwitch events are saved using the FreeSwitchEvent model

## Testing
- `npx mocha --require ts-node/register apps/meteor/tests/unit/server/lib/freeswitch.eventPersistence.tests.ts` *(fails: Cannot find module 'ts-node/register')*

------
https://chatgpt.com/codex/tasks/task_e_6844913cabcc83219256401f0cd83361

## Summary by Sourcery

Tests:
- Add a unit test verifying that parsed FreeSwitch events invoke FreeSwitchEvent.registerEvent with the correct call data