### PR TITLE
Fix countByContactInfo readPreference

### DIFF
--- a/packages/models/src/models/LivechatContacts.ts
+++ b/packages/models/src/models/LivechatContacts.ts
@@ -288,7 +288,7 @@ export class LivechatContactsRaw extends BaseRaw<ILivechatContact> implements IL
 			...(contactId && { _id: contactId }),
 		};
 
-		return this.countDocuments(filter);
+               return this.countDocuments(filter, { readPreference: readSecondaryPreferred() });
 	}
 
 	countUnknown(): Promise<number> {


### PR DESCRIPTION
## Summary
- ensure countByContactInfo counts with secondary preferred readPreference

## Testing
- `yarn testunit` *(fails: This package doesn't seem to be present in your lockfile; run "yarn install" to update the lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6844913924a88321a9990397c991b34d

## Summary by Sourcery

Bug Fixes:
- Apply secondaryPreferred read preference in countByContactInfo's countDocuments call