### PR TITLE
Add timeout to Deno messenger sendRequest

### DIFF
--- a/packages/apps-engine/deno-runtime/lib/messenger.ts
+++ b/packages/apps-engine/deno-runtime/lib/messenger.ts
@@ -167,12 +167,20 @@ export function pongResponse(): Promise<void> {
     return Promise.resolve(Queue.enqueue(COMMAND_PONG));
 }
 
-export async function sendRequest(requestDescriptor: RequestDescriptor): Promise<jsonrpc.SuccessObject> {
-    const request = jsonrpc.request(Math.random().toString(36).slice(2), requestDescriptor.method, requestDescriptor.params);
+export async function sendRequest(
+    requestDescriptor: RequestDescriptor,
+    timeout = 5000,
+): Promise<jsonrpc.SuccessObject> {
+    const request = jsonrpc.request(
+        Math.random().toString(36).slice(2),
+        requestDescriptor.method,
+        requestDescriptor.params,
+    );
 
-    // TODO: add timeout to this
     const responsePromise = new Promise((resolve, reject) => {
         const handler = (event: Event) => {
+            clearTimeout(timer);
+
             if (event instanceof ErrorEvent) {
                 reject(event.error);
             }
@@ -181,8 +189,19 @@ export async function sendRequest(requestDescriptor: RequestDescriptor): Promise
                 resolve(event.detail);
             }
 
-            RPCResponseObserver.removeEventListener(`response:${request.id}`, handler);
+            RPCResponseObserver.removeEventListener(
+                `response:${request.id}`,
+                handler,
+            );
         };
+
+        const timer = setTimeout(() => {
+            RPCResponseObserver.removeEventListener(
+                `response:${request.id}`,
+                handler,
+            );
+            reject(new Error('Response timed out'));
+        }, timeout);
 
         RPCResponseObserver.addEventListener(`response:${request.id}`, handler);
     });

--- a/packages/apps-engine/deno-runtime/lib/tests/messenger.test.ts
+++ b/packages/apps-engine/deno-runtime/lib/tests/messenger.test.ts
@@ -1,4 +1,5 @@
 import { assertEquals, assertObjectMatch } from 'https://deno.land/std@0.203.0/assert/mod.ts';
+import { assert } from 'https://deno.land/std@0.203.0/assert/assert.ts';
 import { afterAll, beforeEach, describe, it } from 'https://deno.land/std@0.203.0/testing/bdd.ts';
 import { spy } from 'https://deno.land/std@0.203.0/testing/mock.ts';
 
@@ -92,5 +93,17 @@ describe('Messenger', () => {
         });
 
         theSpy.restore();
+    });
+
+    it('should timeout if no response is received', async () => {
+        let error: unknown;
+        try {
+            await Messenger.sendRequest({ method: 'test', params: [] }, 10);
+        } catch (e) {
+            error = e;
+        }
+
+        assert(error instanceof Error);
+        assertEquals((error as Error).message, 'Response timed out');
     });
 });


### PR DESCRIPTION
## Summary
- add configurable timeout when waiting for RPC responses
- test messenger timeout behaviour

## Testing
- `apt-get update`
- `curl -fsSL https://deno.land/install.sh | sh` *(fails: 403)*
- `yarn testunit` *(fails: package missing in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_6844a17bc230832192df7f71d81f5fbe

## Summary by Sourcery

Add a configurable timeout to Deno messenger sendRequest calls to reject when no response arrives in time and include a test for timeout behavior

New Features:
- Allow passing a timeout parameter to sendRequest to limit how long it waits for an RPC response

Tests:
- Add a unit test to verify sendRequest rejects with a timeout error if no response is received